### PR TITLE
Remove year from tracker

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
-title: "Tom Waits-løpet 2019 Tracker"
+title: "Tom Waits-løpet Tracker"
 email: kusmabite@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
   Dette er en webapp some lar deg holde oversikt over hvor langt du har
-  kommet i Tom Waits Løpet 2019.
+  kommet i Tom Waits Løpet.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: kusmabite


### PR DESCRIPTION
This will avoid the problem of last year where the tracker was updated with the new bars, but the year was still shown as 2019.